### PR TITLE
Fixed character code for normal to \x0F

### DIFF
--- a/lib/irc-colors.js
+++ b/lib/irc-colors.js
@@ -21,7 +21,7 @@ var colors = {
 };
 
 var styles = {
-  '\x00': 'normal',
+  '\x0F': 'normal',
   '\x1F': 'underline',
   '\x02': 'bold',
   '\x16': 'italic'


### PR DESCRIPTION
Character for normal is \x0F not \x00, which is the null terminator. My test on a server just cut the message off after \x00
