### PR TITLE
package.json: Fix structure of license property

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,5 @@
     "istanbul": "*",
     "vows": "*"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/fent/irc-colors.js/raw/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
As per https://docs.npmjs.com/files/package.json licenses array is not
supposed to be used anymore and causes issues on newer NodeJS/NPM.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>