### PR TITLE
add support for inverted text

### DIFF
--- a/lib/irc-colors.js
+++ b/lib/irc-colors.js
@@ -22,7 +22,7 @@ const styles = {
   underline : '\x1F',
   bold      : '\x02',
   italic    : '\x1D',
-  inverse   : '\u0016'
+  inverse   : '\x16'
 };
 
 const styleChars = {};

--- a/lib/irc-colors.js
+++ b/lib/irc-colors.js
@@ -21,7 +21,8 @@ const styles = {
   normal    : '\x0F',
   underline : '\x1F',
   bold      : '\x02',
-  italic    : '\x1D'
+  italic    : '\x1D',
+  inverted  : '\u0016'
 };
 
 const styleChars = {};

--- a/lib/irc-colors.js
+++ b/lib/irc-colors.js
@@ -22,7 +22,7 @@ const styles = {
   underline : '\x1F',
   bold      : '\x02',
   italic    : '\x1D',
-  inverted  : '\u0016'
+  inverse   : '\u0016'
 };
 
 const styleChars = {};


### PR DESCRIPTION
In addition to the existing styles (bold, italic, underline).

This is not the same as `c.white.bgblack`.